### PR TITLE
주문 생성 Service - 장바구니에 담긴 상품 Info를 가져오는 API 구현

### DIFF
--- a/bucket-api/src/main/generated/org/ecommerce/bucketapi/dto/BucketMapperImpl.java
+++ b/bucket-api/src/main/generated/org/ecommerce/bucketapi/dto/BucketMapperImpl.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-04-14T15:59:17+0900",
+    date = "2024-04-15T10:44:16+0900",
     comments = "version: 1.5.3.Final, compiler: javac, environment: Java 17.0.10 (Amazon.com Inc.)"
 )
 @Component

--- a/bucket-api/src/main/java/org/ecommerce/bucketapi/controller/BucketController.java
+++ b/bucket-api/src/main/java/org/ecommerce/bucketapi/controller/BucketController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
@@ -64,5 +65,19 @@ public class BucketController {
 						bucketService.updateBucket(bucketId, updateRequest)
 				)
 		);
+	}
+
+	// TODO : 회원 검증 로직 추가
+	// TODO : Circuit Breaker 적용 후 장바구니 검증 로직 추가
+	@GetMapping("/{userId}")
+	public List<BucketDto.Response> getBuckets(
+			@PathVariable("userId") final Integer userId,
+			@RequestParam("bucketIds") final List<Long> bucketIds
+	) {
+
+		return bucketService.getBuckets(bucketIds)
+				.stream()
+				.map(BucketDto.Response::of)
+				.toList();
 	}
 }

--- a/bucket-api/src/main/java/org/ecommerce/bucketapi/service/BucketService.java
+++ b/bucket-api/src/main/java/org/ecommerce/bucketapi/service/BucketService.java
@@ -67,4 +67,12 @@ public class BucketService {
 		bucket.update(updateRequest.quantity());
 		return BucketMapper.INSTANCE.toDto(bucket);
 	}
+
+	public List<BucketDto> getBuckets(final List<Long> bucketIds) {
+
+		return bucketRepository.findAllById(bucketIds)
+				.stream()
+				.map(BucketMapper.INSTANCE::toDto)
+				.toList();
+	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,7 @@ project(':order-api'){
         implementation("org.springframework.boot:spring-boot-starter-data-jpa")
         implementation 'org.springframework.boot:spring-boot-starter-validation'
         runtimeOnly 'com.h2database:h2'
+        implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -119,6 +119,11 @@ project(':order-api'){
         runtimeOnly 'com.h2database:h2'
         implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     }
+    dependencyManagement {
+        imports {
+            mavenBom "org.springframework.cloud:spring-cloud-dependencies:2023.0.1"
+        }
+    }
 }
 
 project(':payment-api') {

--- a/order-api/src/main/java/org/ecommerce/orderapi/OrderApiApplication.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/OrderApiApplication.java
@@ -2,8 +2,10 @@ package org.ecommerce.orderapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class OrderApiApplication {
 
   public static void main(String[] args) {

--- a/order-api/src/main/java/org/ecommerce/orderapi/OrderApiApplication.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/OrderApiApplication.java
@@ -4,7 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = {"org.ecommerce.common","org.ecommerce.orderapi"})
 @EnableFeignClients
 public class OrderApiApplication {
 

--- a/order-api/src/main/java/org/ecommerce/orderapi/client/BucketServiceClient.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/client/BucketServiceClient.java
@@ -1,0 +1,20 @@
+package org.ecommerce.orderapi.client;
+
+import java.util.List;
+
+import org.ecommerce.orderapi.vo.ResponseBucket;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "bucket-service", url = "${bucket-service.url}")
+public interface BucketServiceClient {
+
+	// 장바구니에 담겨있는 상품 정보를 가져옴, 검증
+	@GetMapping("/{userId}")
+	List<ResponseBucket> getBuckets(
+			@PathVariable("userId") final Integer userId,
+			@RequestParam final List<Long> bucketIds
+	);
+}

--- a/order-api/src/main/java/org/ecommerce/orderapi/client/BucketServiceClient.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/client/BucketServiceClient.java
@@ -2,7 +2,7 @@ package org.ecommerce.orderapi.client;
 
 import java.util.List;
 
-import org.ecommerce.orderapi.vo.ResponseBucket;
+import org.ecommerce.orderapi.dto.BucketDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -13,8 +13,8 @@ public interface BucketServiceClient {
 
 	// 장바구니에 담겨있는 상품 정보를 가져옴, 검증
 	@GetMapping("/{userId}")
-	List<ResponseBucket> getBuckets(
+	List<BucketDto.Response> getBuckets(
 			@PathVariable("userId") final Integer userId,
-			@RequestParam final List<Long> bucketIds
+			@RequestParam("bucketIds") final List<Long> bucketIds
 	);
 }

--- a/order-api/src/main/java/org/ecommerce/orderapi/dto/BucketDto.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/dto/BucketDto.java
@@ -1,5 +1,7 @@
 package org.ecommerce.orderapi.dto;
 
+import java.time.LocalDate;
+
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
@@ -9,4 +11,15 @@ public class BucketDto {
 	private String seller;
 	private Integer productId;
 	private Integer quantity;
+	private LocalDate createDate;
+
+	public record Response(
+			Long id,
+			Integer userId,
+			String seller,
+			Integer productId,
+			Integer quantity,
+			LocalDate createDate
+	) {
+	}
 }

--- a/order-api/src/main/java/org/ecommerce/orderapi/dto/BucketDto.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/dto/BucketDto.java
@@ -1,0 +1,12 @@
+package org.ecommerce.orderapi.dto;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class BucketDto {
+	private Long id;
+	private Integer userId;
+	private String seller;
+	private Integer productId;
+	private Integer quantity;
+}

--- a/order-api/src/main/java/org/ecommerce/orderapi/dto/BucketMapper.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/dto/BucketMapper.java
@@ -1,6 +1,5 @@
 package org.ecommerce.orderapi.dto;
 
-import org.ecommerce.orderapi.vo.ResponseBucket;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
@@ -10,5 +9,5 @@ public interface BucketMapper {
 
 	BucketMapper INSTANCE = Mappers.getMapper(BucketMapper.class);
 
-	BucketDto toDto(ResponseBucket responseBucket);
+	BucketDto toDto(BucketDto.Response response);
 }

--- a/order-api/src/main/java/org/ecommerce/orderapi/dto/BucketMapper.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/dto/BucketMapper.java
@@ -1,0 +1,14 @@
+package org.ecommerce.orderapi.dto;
+
+import org.ecommerce.orderapi.vo.ResponseBucket;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface BucketMapper {
+
+	BucketMapper INSTANCE = Mappers.getMapper(BucketMapper.class);
+
+	BucketDto toDto(ResponseBucket responseBucket);
+}

--- a/order-api/src/main/java/org/ecommerce/orderapi/dto/OrderDto.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/dto/OrderDto.java
@@ -26,7 +26,7 @@ public class OrderDto {
 		public record Create(
 
 				@NotNull(message = "주문할 장바구니를 입력해 주세요.")
-				List<Long> buckets,
+				List<Long> bucketIds,
 
 				@NotBlank(message = "수신자 이름을 입력해 주세요.")
 				String receiveName,

--- a/order-api/src/main/java/org/ecommerce/orderapi/repository/OrderDetailRepository.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/repository/OrderDetailRepository.java
@@ -1,0 +1,7 @@
+package org.ecommerce.orderapi.repository;
+
+import org.ecommerce.orderapi.entity.OrderDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderDetailRepository extends JpaRepository<OrderDetail, Long> {
+}

--- a/order-api/src/main/java/org/ecommerce/orderapi/repository/OrderRepository.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/repository/OrderRepository.java
@@ -1,0 +1,9 @@
+package org.ecommerce.orderapi.repository;
+
+import org.ecommerce.orderapi.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/order-api/src/main/java/org/ecommerce/orderapi/service/OrderService.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/service/OrderService.java
@@ -1,0 +1,45 @@
+package org.ecommerce.orderapi.service;
+
+import java.util.List;
+
+import org.ecommerce.orderapi.client.BucketServiceClient;
+import org.ecommerce.orderapi.dto.BucketDto;
+import org.ecommerce.orderapi.dto.BucketMapper;
+import org.ecommerce.orderapi.dto.OrderDto;
+import org.ecommerce.orderapi.repository.OrderDetailRepository;
+import org.ecommerce.orderapi.repository.OrderRepository;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+	private final BucketServiceClient bucketServiceClient;
+	private final OrderRepository orderRepository;
+	private final OrderDetailRepository orderDetailRepository;
+
+	// TODO user-service 검증 : user-service 구축 이후
+	// TODO bucket-service 상품 가져오기, 장바구니 검증
+	// TODO product-service  재고 및 상품 검증 : product-service 구축 이후
+	// TODO payment-service 결제 과정 : payment-service 구축 이후
+
+	public List<BucketDto> getBuckets(
+			final Integer userId,
+			final List<Long> bucketIds
+	) {
+		return bucketServiceClient.getBuckets(userId, bucketIds)
+				.stream()
+				.map(BucketMapper.INSTANCE::toDto)
+				.toList();
+	}
+
+	public OrderDto createOrder(
+			final Integer userId,
+			final OrderDto.Request.Create createRequest,
+			final List<BucketDto> bucketDtos
+	) {
+		return null;
+	}
+}

--- a/order-api/src/main/java/org/ecommerce/orderapi/service/OrderService.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/service/OrderService.java
@@ -25,6 +25,18 @@ public class OrderService {
 	// TODO product-service  재고 및 상품 검증 : product-service 구축 이후
 	// TODO payment-service 결제 과정 : payment-service 구축 이후
 
+	/**
+	 * 주문 생성에 필요한 정보를 가져오는 메소드를 호출합니다.
+	 * <p>
+	 * Bucket-Service 유저정보와, 장바구니 번호들을 보내서
+	 * 검증 후 주문 생성에 필요한 상품 정보를 반환 받습니다.
+	 * <p>
+	 * @author ${Juwon}
+	 *
+	 * @param userId- 주문을 생성하는 회원 번호
+	 * @param bucketIds- 회원이 주문하는 장바구니 번호가 들어있는 리스트
+	 * @return - 장바구니 정보가 들어있는 BucketDto 입니다.
+	*/
 	public List<BucketDto> getBuckets(
 			final Integer userId,
 			final List<Long> bucketIds

--- a/order-api/src/main/java/org/ecommerce/orderapi/vo/ResponseBucket.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/vo/ResponseBucket.java
@@ -1,0 +1,9 @@
+package org.ecommerce.orderapi.vo;
+
+public class ResponseBucket {
+	private Long id;
+	private Integer userId;
+	private String seller;
+	private Integer productId;
+	private Integer quantity;
+}

--- a/order-api/src/main/java/org/ecommerce/orderapi/vo/ResponseBucket.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/vo/ResponseBucket.java
@@ -1,9 +1,0 @@
-package org.ecommerce.orderapi.vo;
-
-public class ResponseBucket {
-	private Long id;
-	private Integer userId;
-	private String seller;
-	private Integer productId;
-	private Integer quantity;
-}

--- a/order-api/src/main/resources/application.yml
+++ b/order-api/src/main/resources/application.yml
@@ -1,5 +1,7 @@
 server:
   port: 8081
+bucket-service:
+  url: http://localhost:8080/api/buckets/v1
 spring:
   application:
     name: order-api


### PR DESCRIPTION
## 개요
장바구니 검증을 위해 Order-Service에서 Bucket-Service와 동기적으로 통신을하는 Service를 구현했습니다.
기능 구현을 먼저하고 추후 예외처리까지 진행하겠습니다. (feat. Circuit Breaker)
TestCode는 주문 생성 API 완성 이후 작성하겠습니다 😢 

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 주석 추가 및 수정
- [x] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 

> ### Description

- 주문 생성 Controller, Service, Dto    base 구현
- Order-Service와 Bucket-Service FeignClient를 통한 통신 Service 구현
- JavaDoc 작성을 시작하였습니다. 해당 서비스를 작성/수정 시 하나씩 기입하겠습니다.
  - 다들 아시겠지만 잊어버리셨을 수 있어서 팁 남깁니다! 
  - 라이브 템플릿 사용법 (약어를 통해 코드를 자동완성 시켜주는 기능입니다.) 현재 저는 Test Code랑, JavaDocs를 만들 때 사용하고 있습니다.
![image](https://github.com/Team-Koreano/Koreano/assets/90291431/26782e69-8ec0-4a2a-b614-3a59a8281931)
```java
/**
 * 1줄 짜리 간결한 설명 ------- (1)
 * <p>
 * 긴 설명 
 * <p>
 * @author ${USER}
 *
 * @param - 변수 설명 텍스트
 * @return - 반환 값 설명 텍스트
*/
```
![image](https://github.com/Team-Koreano/Koreano/assets/90291431/31bdff88-ba92-4419-92cf-6464f3e12fcd)




> ### Core Code
- `@PathVariable`, `@RequestParam`를 사용할 때 정확한 Parameter Name을 입력해 주셔야 안정적으로 동작합니다. 미기입 시
`Caused by: java.lang.IllegalStateException: RequestParam.value() was empty on parameter 1 of method getBuckets` 와 같은 Exception이 발생할 수 있습니다.


```java
@FeignClient(name = "bucket-service", url = "${bucket-service.url}")
public interface BucketServiceClient {

	// 장바구니에 담겨있는 상품 정보를 가져옴, 검증
	@GetMapping("/{userId}")
	List<BucketDto.Response> getBuckets(
			@PathVariable("userId") final Integer userId,
			@RequestParam("bucketIds") final List<Long> bucketIds
	);
}
```
