### PR TITLE
[결제] 토스 사전충전실패 API 구현

### DIFF
--- a/payment-api/src/main/java/org/ecommerce/paymentapi/controller/BeanPayController.java
+++ b/payment-api/src/main/java/org/ecommerce/paymentapi/controller/BeanPayController.java
@@ -37,6 +37,10 @@ public class BeanPayController {
 		if(response.getProcessStatus() == CANCELLED) return new Response<>(HttpStatus.BAD_REQUEST.value(), response);
 		return new Response<>(HttpStatus.OK.value(), response);
 	}
+
+	@GetMapping("/fail")
+	public Response<BeanPayDto> failCharge(@Valid final BeanPayDto.Request.TossFail request) {
+		final BeanPayDto response = beanPayService.failTossCharge(request);
 		return new Response<>(HttpStatus.OK.value(), response);
 	}
 

--- a/payment-api/src/main/java/org/ecommerce/paymentapi/controller/BeanPayController.java
+++ b/payment-api/src/main/java/org/ecommerce/paymentapi/controller/BeanPayController.java
@@ -1,5 +1,7 @@
 package org.ecommerce.paymentapi.controller;
 
+import static org.ecommerce.paymentapi.entity.type.ProcessStatus.*;
+
 import org.ecommerce.common.vo.Response;
 import org.ecommerce.paymentapi.dto.BeanPayDto;
 import org.ecommerce.paymentapi.service.BeanPayService;
@@ -32,6 +34,9 @@ public class BeanPayController {
 	@GetMapping("/success")
 	public Response<BeanPayDto> validCharge(@Valid final BeanPayDto.Request.TossPayment request) {
 		final BeanPayDto response = beanPayService.validTossCharge(request);
+		if(response.getProcessStatus() == CANCELLED) return new Response<>(HttpStatus.BAD_REQUEST.value(), response);
+		return new Response<>(HttpStatus.OK.value(), response);
+	}
 		return new Response<>(HttpStatus.OK.value(), response);
 	}
 

--- a/payment-api/src/main/java/org/ecommerce/paymentapi/dto/BeanPayDto.java
+++ b/payment-api/src/main/java/org/ecommerce/paymentapi/dto/BeanPayDto.java
@@ -62,7 +62,11 @@ public class BeanPayDto {
 		}
 
 		public record TossFail(
+			@NotNull(message = "충전ID를 입력해주세요")
+			UUID orderId,
+			@NotBlank(message = "에러코드를 입력해주세요")
 			String errorCode,
+			@NotBlank(message = "에러메시지를 입력해주세요")
 			String errorMessage
 		) {
 		}

--- a/payment-api/src/main/java/org/ecommerce/paymentapi/entity/BeanPay.java
+++ b/payment-api/src/main/java/org/ecommerce/paymentapi/entity/BeanPay.java
@@ -93,8 +93,8 @@ public class BeanPay {
 		this.approveDateTime = stringToDateTime(response.approveDateTime());
 	}
 
-	public void fail(ErrorCode errorCode) {
-		this.cancelOrFailReason = errorCode.getMessage();
+	public void fail(String message) {
+		this.cancelOrFailReason = message;
 		this.processStatus = ProcessStatus.CANCELLED;
 	}
 }

--- a/payment-api/src/main/java/org/ecommerce/paymentapi/service/BeanPayService.java
+++ b/payment-api/src/main/java/org/ecommerce/paymentapi/service/BeanPayService.java
@@ -50,8 +50,6 @@ public class BeanPayService {
 	 * @param - BeanPayDto.Request.TossPayment request
 	 * @return - BeanPayDto response
 	 */
-
-	@Transactional(readOnly = true)
 	public BeanPayDto validTossCharge(final BeanPayDto.Request.TossPayment request) {
 		log.info("request : {} {} {}", request.paymentKey(), request.orderId(), request.amount());
 
@@ -61,8 +59,6 @@ public class BeanPayService {
 			processInProgress(findBeanPay);
 			validateBeanPay(findBeanPay, request);
 		} catch (CustomException e) {
-			handleException(findBeanPay, e);
-			throw e;
 			handleException(findBeanPay, e.getErrorMessage());
 			return BeanPayMapper.INSTANCE.toDto(findBeanPay);
 		}
@@ -71,10 +67,8 @@ public class BeanPayService {
 			processApproval(findBeanPay, request);
 			return BeanPayMapper.INSTANCE.toDto(findBeanPay);
 		} catch (CustomException e) {
-			handleException(findBeanPay, e);
 			handleException(findBeanPay, e.getErrorMessage());
 			//TODO: 유저 beanPay 롤백 로직 작성
-			throw e;
 			return BeanPayMapper.INSTANCE.toDto(findBeanPay);
 		}
 	}
@@ -142,7 +136,22 @@ public class BeanPayService {
 	 * @param - BeanPay findBeanPay, CustomException e
 	 * @return - void
 	 * */
-	private void handleException(final BeanPay findBeanPay, final CustomException e) {
-		findBeanPay.fail(e.getErrorCode());
+	private void handleException(final BeanPay findBeanPay, final String message) {
+		findBeanPay.fail(message);
+	}
+
+	/**
+	 * 사전결제 실패 시
+	 * @author 이우진
+	 *
+	 * @param - BeanPayDto.Request.TossFail request
+	 * @return - BeanPayDto
+	 */
+	public BeanPayDto failTossCharge(BeanPayDto.Request.TossFail request) {
+
+		BeanPay findBeanPay = findBeanPayById(request.orderId());
+		handleException(findBeanPay, request.errorMessage());
+
+		return BeanPayMapper.INSTANCE.toDto(findBeanPay);
 	}
 }

--- a/payment-api/src/main/java/org/ecommerce/paymentapi/service/BeanPayService.java
+++ b/payment-api/src/main/java/org/ecommerce/paymentapi/service/BeanPayService.java
@@ -63,6 +63,8 @@ public class BeanPayService {
 		} catch (CustomException e) {
 			handleException(findBeanPay, e);
 			throw e;
+			handleException(findBeanPay, e.getErrorMessage());
+			return BeanPayMapper.INSTANCE.toDto(findBeanPay);
 		}
 		try {
 			//TODO: 유저 beanPay 추가 로직 작성
@@ -70,8 +72,10 @@ public class BeanPayService {
 			return BeanPayMapper.INSTANCE.toDto(findBeanPay);
 		} catch (CustomException e) {
 			handleException(findBeanPay, e);
+			handleException(findBeanPay, e.getErrorMessage());
 			//TODO: 유저 beanPay 롤백 로직 작성
 			throw e;
+			return BeanPayMapper.INSTANCE.toDto(findBeanPay);
 		}
 	}
 

--- a/payment-api/src/test/java/org/ecommerce/paymentapi/dto/BeanPayDtoTest.java
+++ b/payment-api/src/test/java/org/ecommerce/paymentapi/dto/BeanPayDtoTest.java
@@ -80,4 +80,41 @@ class BeanPayDtoTest {
 		}
 	}
 
+	@Nested
+	class 토스사전결제_실패_DTO {
+		@Test
+		void 성공() {
+			//given
+			final UUID orderId = UUID.randomUUID();
+			final String errorMessage = "사용자에 의해 결제가 취소되었습니다.";
+			final String errorCode = "PAY_PROCESS_CANCELED";
+
+			//when
+			final BeanPayDto.Request.TossFail request =
+				new BeanPayDto.Request.TossFail(orderId, errorCode, errorMessage);
+
+			//then
+			assertEquals(orderId, request.orderId());
+			assertEquals(errorMessage, request.errorMessage());
+			assertEquals(errorCode, request.errorCode());
+		}
+		@Test
+		void 실패() {
+			//given
+			final UUID orderId = null;
+			final String errorMessage = "";
+			final String errorCode = "";
+
+			//when
+			final BeanPayDto.Request.TossFail request =
+				new BeanPayDto.Request.TossFail(orderId, errorMessage, errorCode);
+
+			//then
+			Set<ConstraintViolation<BeanPayDto.Request.TossFail>> violations =
+				validator.validate(request);
+
+			assertEquals(3, violations.size());
+		}
+	}
+
 }

--- a/payment-api/src/test/java/org/ecommerce/paymentapi/entity/BeanPayTest.java
+++ b/payment-api/src/test/java/org/ecommerce/paymentapi/entity/BeanPayTest.java
@@ -108,7 +108,7 @@ class BeanPayTest {
 			final BeanPay actual = getBeanPay(orderId, paymentKey, userId, amount, paymentType);
 
 			//when
-			actual.fail(TOSS_RESPONSE_FAIL);
+			actual.fail(TOSS_RESPONSE_FAIL.getMessage());
 
 			//then
 			assertEquals(actual.getProcessStatus(), ProcessStatus.CANCELLED);

--- a/payment-api/src/test/java/org/ecommerce/paymentapi/service/BeanPayServiceTest.java
+++ b/payment-api/src/test/java/org/ecommerce/paymentapi/service/BeanPayServiceTest.java
@@ -92,6 +92,7 @@ class BeanPayServiceTest {
 
 		@Test
 		void 빈페이_존재_안함_예외발생() {
+		void 빈페이_존재안함_예외발생() {
 
 			//given
 			final UUID orderId = UUID.randomUUID();
@@ -137,12 +138,15 @@ class BeanPayServiceTest {
 				beanPayService.validTossCharge(request);
 			});
 			assertEquals(returnException.getErrorCode(), VERIFICATION_FAIL);
+			assertDoesNotThrow(() -> beanPayService.validTossCharge(request));
 			assertTrue(optionalBeanPay.isPresent());
+			assertEquals(optionalBeanPay.get().getCancelOrFailReason(), VERIFICATION_FAIL.getMessage());
 			assertEquals(ProcessStatus.CANCELLED, optionalBeanPay.get().getProcessStatus());
 		}
 
 		@Test
 		void 토스_검증_승인_예외발생() {
+		void 토스검증승인_예외발생() {
 			//given
 			final UUID orderId = UUID.randomUUID();
 			final Integer userId = 1;
@@ -172,7 +176,9 @@ class BeanPayServiceTest {
 				beanPayService.validTossCharge(request);
 			});
 			assertEquals(returnException.getErrorCode(), TOSS_RESPONSE_FAIL);
+			assertDoesNotThrow(() -> beanPayService.validTossCharge(request));
 			assertTrue(optionalBeanPay.isPresent());
+			assertEquals(optionalBeanPay.get().getCancelOrFailReason(), TOSS_RESPONSE_FAIL.getMessage());
 			assertEquals(ProcessStatus.CANCELLED, optionalBeanPay.get().getProcessStatus());
 		}
 

--- a/payment-api/src/test/java/org/ecommerce/paymentapi/service/BeanPayServiceTest.java
+++ b/payment-api/src/test/java/org/ecommerce/paymentapi/service/BeanPayServiceTest.java
@@ -91,7 +91,6 @@ class BeanPayServiceTest {
 		}
 
 		@Test
-		void 빈페이_존재_안함_예외발생() {
 		void 빈페이_존재안함_예외발생() {
 
 			//given
@@ -134,10 +133,6 @@ class BeanPayServiceTest {
 			Optional<BeanPay> optionalBeanPay = beanPayRepository.findById(request.orderId());
 
 			//then
-			CustomException returnException = assertThrows(CustomException.class, () -> {
-				beanPayService.validTossCharge(request);
-			});
-			assertEquals(returnException.getErrorCode(), VERIFICATION_FAIL);
 			assertDoesNotThrow(() -> beanPayService.validTossCharge(request));
 			assertTrue(optionalBeanPay.isPresent());
 			assertEquals(optionalBeanPay.get().getCancelOrFailReason(), VERIFICATION_FAIL.getMessage());
@@ -145,7 +140,6 @@ class BeanPayServiceTest {
 		}
 
 		@Test
-		void 토스_검증_승인_예외발생() {
 		void 토스검증승인_예외발생() {
 			//given
 			final UUID orderId = UUID.randomUUID();
@@ -172,10 +166,6 @@ class BeanPayServiceTest {
 			Optional<BeanPay> optionalBeanPay = beanPayRepository.findById(request.orderId());
 
 			//then
-			CustomException returnException = assertThrows(CustomException.class, () -> {
-				beanPayService.validTossCharge(request);
-			});
-			assertEquals(returnException.getErrorCode(), TOSS_RESPONSE_FAIL);
 			assertDoesNotThrow(() -> beanPayService.validTossCharge(request));
 			assertTrue(optionalBeanPay.isPresent());
 			assertEquals(optionalBeanPay.get().getCancelOrFailReason(), TOSS_RESPONSE_FAIL.getMessage());
@@ -183,5 +173,53 @@ class BeanPayServiceTest {
 		}
 
 	}
+
+	@Nested
+	class 토스사전결제_실패 {
+		@Test
+		void 성공() {
+			//given
+			final UUID orderId = UUID.randomUUID();
+			final Integer userId = 1;
+			final Integer amount = 1000;
+			final String errorMessage = "사용자에 의해 결제가 취소되었습니다.";
+			final String errorCode = "PAY_PROCESS_CANCELED";
+
+			final BeanPayDto.Request.TossFail request = new BeanPayDto.Request.TossFail(orderId, errorCode, errorMessage);
+
+			final BeanPay entity = new BeanPay(orderId, null, userId, amount, null, errorMessage,
+				BeanPayStatus.DEPOSIT, ProcessStatus.CANCELLED, LocalDateTime.now(), null);
+
+			//when
+			when(beanPayRepository.findById(request.orderId())).thenReturn(Optional.of(entity));
+			Optional<BeanPay> optionalBeanPay = beanPayRepository.findById(request.orderId());
+
+			//then
+			assertDoesNotThrow(() -> beanPayService.failTossCharge(request));
+			assertTrue(optionalBeanPay.isPresent());
+			assertEquals(optionalBeanPay.get().getCancelOrFailReason(), errorMessage);
+			assertEquals(ProcessStatus.CANCELLED, optionalBeanPay.get().getProcessStatus());
+		}	
+	}
+	@Test
+	void 빈페이_존재안함_예외발생() {
+		//given
+		final UUID orderId = UUID.randomUUID();
+		final String errorMessage = "사용자에 의해 결제가 취소되었습니다.";
+		final String errorCode = "PAY_PROCESS_CANCELED";
+
+		final BeanPayDto.Request.TossFail request = new BeanPayDto.Request.TossFail(orderId, errorCode, errorMessage);
+
+		//when
+		when(beanPayRepository.findById(request.orderId())).thenThrow(
+			new CustomException(NOT_EXIST));
+
+		//then
+		CustomException returnException = assertThrows(CustomException.class, () -> {
+			beanPayService.failTossCharge(request);
+		});
+		assertEquals(returnException.getErrorCode(), NOT_EXIST);
+	}
+	
 
 }


### PR DESCRIPTION
## 개요
토스에서 결제로직 실패했을 때 로그를 남기기 위한 API
branch: #60 

```mermaid
sequenceDiagram
Client ->> Payment API: 사전 충전 금액 기록
Payment API ->> Client: 충전 ID반환
Client ->> Toss API : 충전 요청
Toss API  ->> Client: Redirect URL 반환
Client ->> Payment API: payment/fail 
Payment API ->> Client: 충전 번호 존재 X(실패)
Payment API ->> Client: 결제 실패 반환(성공)
```
## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 테스트 추가, 테스트 리팩토링

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

> ### Description

- [x] 수정해야할 코드 Refactor ✅ 2024-04-18
	- [x] 검증로직 예외 발생시 DTO 반환 ✅ 2024-04-18
- [x] 사전충전 실패 로직 작성 ✅ 2024-04-18
    - [x] 컨트롤러 ✅ 2024-04-18
    - [x] 서비스 ✅ 2024-04-18
    - [x] 예외 ✅ 2024-04-18
    - [x] Dto ✅ 2024-04-18
- [x] 테스트 코드 작성 ✅ 2024-04-18
    - [x] 컨트롤러 ✅ 2024-04-18
    - [x] 서비스 ✅ 2024-04-18
    - [x] Dto ✅ 2024-04-18

> ## Core Code
### Refactor: 검증로직 예외 발생시 DTO 반환
```java
		try {
			processInProgress(findBeanPay);
			validateBeanPay(findBeanPay, request);
		} catch (CustomException e) {
			handleException(findBeanPay, e.getErrorMessage());
			return BeanPayMapper.INSTANCE.toDto(findBeanPay);
		}
		try {
			//TODO: 유저 beanPay 추가 로직 작성
			processApproval(findBeanPay, request);
			return BeanPayMapper.INSTANCE.toDto(findBeanPay);
		} catch (CustomException e) {
			handleException(findBeanPay, e.getErrorMessage());
			//TODO: 유저 beanPay 롤백 로직 작성
			return BeanPayMapper.INSTANCE.toDto(findBeanPay);
		}
```
위에서 예외가 발생해도 현재 상태를 남기기 위해 GlobalExceptionHandler 에서 처리하는게 아닌 DTO를 반환함

### Feat: 사전충전실패 로직
```java
	public BeanPayDto failTossCharge(BeanPayDto.Request.TossFail request) {

		BeanPay findBeanPay = findBeanPayById(request.orderId());
		handleException(findBeanPay, request.errorMessage());

		return BeanPayMapper.INSTANCE.toDto(findBeanPay);
	}
```