### PR TITLE
주문에 대한 재고 처리

### DIFF
--- a/order-api/src/main/java/org/ecommerce/orderapi/client/BucketServiceClient.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/client/BucketServiceClient.java
@@ -15,7 +15,7 @@ public interface BucketServiceClient {
 	// 장바구니에 담겨있는 상품 정보를 가져옴, 검증
 	// jwt 도입 이후 userId 삭제
 	@GetMapping("/{userId}")
-	List<BucketDto.Response> validateBuckets(
+	List<BucketDto.Response> getBuckets(
 			@PathVariable("userId") final Integer userId,
 			@RequestParam("bucketIds") final List<Long> bucketIds
 	);

--- a/order-api/src/main/java/org/ecommerce/orderapi/client/RedisClient.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/client/RedisClient.java
@@ -17,8 +17,8 @@ public class RedisClient {
 
 	private final RedissonClient redissonClient;
 	private static final String STOCK_KEY = "stock:";
-	private static final String TOTAL_KEY = "total:%s:";
-	private static final String IN_PROCESSING_KEY = "inProcessing:%s:";
+	private static final String TOTAL_KEY = "total:";
+	private static final String IN_PROCESSING_KEY = "inProcessing:";
 	private static final String PRODUCT_KEY = "product:";
 
 	private void addStock(
@@ -91,10 +91,10 @@ public class RedisClient {
 	}
 
 	private String getStockTotalKey(final String key) {
-		return String.format(TOTAL_KEY, key);
+		return TOTAL_KEY + key;
 	}
 
 	private String getInProcessingStockKey(final String key) {
-		return String.format(IN_PROCESSING_KEY, key);
+		return IN_PROCESSING_KEY + key;
 	}
 }

--- a/order-api/src/main/java/org/ecommerce/orderapi/client/RedisClient.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/client/RedisClient.java
@@ -5,13 +5,16 @@ import java.util.Optional;
 
 import org.ecommerce.orderapi.entity.Product;
 import org.ecommerce.orderapi.entity.Stock;
+import org.redisson.api.RLock;
 import org.redisson.api.RMap;
+import org.redisson.api.RTransaction;
 import org.redisson.api.RedissonClient;
-import org.springframework.stereotype.Service;
+import org.redisson.api.TransactionOptions;
+import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
 
-@Service
+@Component
 @RequiredArgsConstructor
 public class RedisClient {
 
@@ -20,24 +23,20 @@ public class RedisClient {
 	private static final String TOTAL_KEY = "total:";
 	private static final String IN_PROCESSING_KEY = "inProcessing:";
 	private static final String PRODUCT_KEY = "product:";
+	private static final String TRANSACTION_KEY = "transaction:";
 
-	private void addStock(
-			final Integer productId,
-			final Integer totalStock,
-			final Integer inProcessingStock
-	) {
-		String key = productId.toString();
-		RMap<String, Integer> stockMap = redissonClient.getMap(STOCK_KEY);
-		stockMap.put(getStockTotalKey(key), totalStock);
-		stockMap.put(getInProcessingStockKey(key), inProcessingStock);
+	public void putStock(final Stock stock) {
+		Integer key = stock.getProductId();
+		RMap<String, Integer> stockMap = redissonClient.getMap(getStockKey(key));
+		stockMap.put(getTotalKey(key), stock.getTotal());
+		stockMap.put(getInProcessingKey(key), stock.getProcessingCnt());
 	}
 
 	public Optional<Stock> getStock(final Integer productId) {
-		String key = productId.toString();
-		RMap<String, Integer> map = redissonClient.getMap(STOCK_KEY);
+		RMap<String, Integer> map = redissonClient.getMap(getStockKey(productId));
 
-		Integer totalStock = map.get(getStockTotalKey(key));
-		Integer inProcessingStock = map.get(getInProcessingStockKey(key));
+		Integer totalStock = map.get(getTotalKey(productId));
+		Integer inProcessingStock = map.get(getInProcessingKey(productId));
 
 		if (totalStock == null || inProcessingStock == null) {
 			return Optional.empty();
@@ -47,54 +46,73 @@ public class RedisClient {
 	}
 
 	public List<Stock> getStocks(final List<Integer> productIds) {
-		RMap<String, Integer> stockMap = redissonClient.getMap(STOCK_KEY);
 		return productIds.stream()
 				.map(productId -> {
-					String key = productId.toString();
+					RMap<String, Integer> map = redissonClient.getMap(
+							getStockKey(productId));
 					return new Stock(
 							productId,
-							stockMap.get(getStockTotalKey(key)),
-							stockMap.get(getInProcessingStockKey(key))
+							map.get(getTotalKey(productId)),
+							map.get(getInProcessingKey(productId))
 					);
-				})
-				.toList();
-	}
-
-	public void registerProduct(final Product product, final Stock stock) {
-		registerProduct(product.getId().toString(), product, stock);
-	}
-
-	private void registerProduct(
-			final String key,
-			final Product product,
-			final Stock stock
-	) {
-		RMap<String, Product> productMap = redissonClient.getMap(PRODUCT_KEY);
-		productMap.put(key, product);
-		addStock(stock.getProductId(), stock.getTotal(), stock.getProcessingCnt());
+				}).toList();
 	}
 
 	public Optional<Product> getProduct(final Integer productId) {
-		String key = productId.toString();
-		RMap<String, Product> productMap = redissonClient.getMap(PRODUCT_KEY);
-		return Optional.ofNullable(productMap.get(key));
+		return Optional.ofNullable(
+				(Product)redissonClient.getBucket(getProductKey(productId)).get());
 	}
 
 	public List<Product> getProducts(final List<Integer> productIds) {
-		RMap<String, Product> productMap = redissonClient.getMap(PRODUCT_KEY);
 		return productIds.stream()
-				.map(productId -> {
-					String key = productId.toString();
-					return productMap.get(key);
-				})
+				.map(productId -> (Product)redissonClient
+						.getBucket(getProductKey(productId)).get())
 				.toList();
 	}
 
-	private String getStockTotalKey(final String key) {
-		return TOTAL_KEY + key;
+	public void setProduct(final Product product) {
+		redissonClient.getBucket(getProductKey(product.getId())).set(product);
 	}
 
-	private String getInProcessingStockKey(final String key) {
-		return IN_PROCESSING_KEY + key;
+	public RTransaction beginTransaction() {
+		return redissonClient.createTransaction(TransactionOptions.defaults());
+	}
+
+	public void increaseInProcessingStock(final RTransaction transaction, final Stock stock) {
+		Integer key = stock.getProductId();
+		RMap<String, Integer> map = transaction.getMap(getStockKey(key));
+		map.put(getTotalKey(key), stock.getTotal());
+		map.put(getInProcessingKey(key), stock.getProcessingCnt());
+	}
+
+	public void soldOutProduct(final RTransaction transaction, final Product product) {
+		Integer key = product.getId();
+		transaction.getBucket(getProductKey(key)).set(product);
+	}
+
+	public RLock getLock(final Integer productId) {
+		RLock lock = redissonClient.getLock(getTransactionLock(productId));
+		lock.lock();
+		return lock;
+	}
+
+	private String getStockKey(final Integer key) {
+		return STOCK_KEY + key.toString();
+	}
+
+	private String getTotalKey(final Integer key) {
+		return TOTAL_KEY + key.toString();
+	}
+
+	private String getInProcessingKey(final Integer key) {
+		return IN_PROCESSING_KEY + key.toString();
+	}
+
+	private String getProductKey(final Integer key) {
+		return PRODUCT_KEY + key.toString();
+	}
+
+	private String getTransactionLock(final Integer key) {
+		return TRANSACTION_KEY + key.toString();
 	}
 }

--- a/order-api/src/main/java/org/ecommerce/orderapi/entity/OrderDetail.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/entity/OrderDetail.java
@@ -1,8 +1,12 @@
 package org.ecommerce.orderapi.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.ecommerce.orderapi.entity.type.OrderStatus;
 import org.ecommerce.orderapi.entity.type.OrderStatusReason;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -13,6 +17,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.Getter;
 
@@ -58,6 +63,9 @@ public class OrderDetail {
 	@Enumerated(EnumType.STRING)
 	private OrderStatusReason statusReason;
 
+	@OneToMany(mappedBy = "orderDetail", cascade = CascadeType.ALL)
+	private List<OrderStatusHistory> orderStatusHistories = new ArrayList<>();
+
 	public static OrderDetail ofPlace(
 			final Order order,
 			final Integer productId,
@@ -77,4 +85,9 @@ public class OrderDetail {
 		orderDetail.seller = seller;
 		return orderDetail;
 	}
+
+	public void recordOrderStatusHistory(final OrderStatusHistory orderStatusHistory) {
+		orderStatusHistories.add(orderStatusHistory);
+	}
+
 }

--- a/order-api/src/main/java/org/ecommerce/orderapi/entity/OrderStatusHistory.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/entity/OrderStatusHistory.java
@@ -38,4 +38,14 @@ public class OrderStatusHistory {
 	@CreationTimestamp
 	@Column
 	private LocalDateTime statusChangeDatetime;
+
+	public static OrderStatusHistory ofRecord(
+			final OrderDetail orderDetail,
+			final OrderStatus changeStatus
+	) {
+		final OrderStatusHistory orderStatusHistory = new OrderStatusHistory();
+		orderStatusHistory.orderDetail = orderDetail;
+		orderStatusHistory.changeStatus = changeStatus;
+		return orderStatusHistory;
+	}
 }

--- a/order-api/src/main/java/org/ecommerce/orderapi/entity/Product.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/entity/Product.java
@@ -19,4 +19,8 @@ public class Product {
 	private Integer price;
 	private String seller;
 	private ProductStatus status;
+
+	public void changeStatus(ProductStatus newStatus) {
+		this.status = newStatus;
+	}
 }

--- a/order-api/src/main/java/org/ecommerce/orderapi/entity/Product.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/entity/Product.java
@@ -1,5 +1,6 @@
 package org.ecommerce.orderapi.entity;
 
+import org.ecommerce.orderapi.entity.type.ProductStatus;
 import org.springframework.data.redis.core.RedisHash;
 
 import jakarta.persistence.Id;
@@ -17,4 +18,5 @@ public class Product {
 	private String name;
 	private Integer price;
 	private String seller;
+	private ProductStatus status;
 }

--- a/order-api/src/main/java/org/ecommerce/orderapi/entity/Stock.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/entity/Stock.java
@@ -15,4 +15,8 @@ public class Stock {
 	public Integer getAvailableStock() {
 		return this.total - this.processingCnt;
 	}
+
+	public void increaseProcessingCnt(final Integer quantity) {
+		this.processingCnt += quantity;
+	}
 }

--- a/order-api/src/main/java/org/ecommerce/orderapi/entity/StockHistory.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/entity/StockHistory.java
@@ -1,0 +1,52 @@
+package org.ecommerce.orderapi.entity;
+
+import static org.ecommerce.orderapi.entity.type.StockOperationType.*;
+
+import org.ecommerce.orderapi.entity.type.StockOperationType;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Entity
+@Table(name = "stock_history",
+		indexes = {@Index(name = "idx_orderDetailId", columnList = "orderDetailId")})
+@Getter
+public class StockHistory {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private Long orderDetailId;
+
+	@Column(nullable = false)
+	private Integer productId;
+
+	@Column(nullable = false)
+	private Integer quantity;
+
+	@Column
+	@Enumerated(EnumType.STRING)
+	private StockOperationType operationType = INCREASE;
+
+	public static StockHistory ofRecord(
+			final Long orderDetailId,
+			final Integer productId,
+			final Integer quantity
+	) {
+		final StockHistory stockHistory = new StockHistory();
+		stockHistory.orderDetailId = orderDetailId;
+		stockHistory.productId = productId;
+		stockHistory.quantity = quantity;
+		return stockHistory;
+	}
+}

--- a/order-api/src/main/java/org/ecommerce/orderapi/entity/type/ProductStatus.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/entity/type/ProductStatus.java
@@ -1,0 +1,21 @@
+package org.ecommerce.orderapi.entity.type;
+
+import org.ecommerce.common.utils.mapper.EnumMapperType;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ProductStatus implements EnumMapperType {
+
+	AVAILABLE("구매 가능"),
+	OUT_OF_STOCK("재고 없음"),
+	DISCONTINUED("판매 중단");
+	private final String title;
+
+	@Override
+	public String getCode() {
+		return name();
+	}
+}

--- a/order-api/src/main/java/org/ecommerce/orderapi/entity/type/StockOperationType.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/entity/type/StockOperationType.java
@@ -1,0 +1,22 @@
+package org.ecommerce.orderapi.entity.type;
+
+import org.ecommerce.common.utils.mapper.EnumMapperType;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum StockOperationType implements EnumMapperType {
+
+	INCREASE("재고 증가"),
+	DECREASE("재고 감소")
+	;
+
+	private final String title;
+
+	@Override
+	public String getCode() {
+		return name();
+	}
+}

--- a/order-api/src/main/java/org/ecommerce/orderapi/exception/OrderErrorCode.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/exception/OrderErrorCode.java
@@ -11,7 +11,8 @@ import lombok.RequiredArgsConstructor;
 public enum OrderErrorCode implements ErrorCode {
 	NOT_FOUND_PRODUCT_ID(HttpStatus.BAD_REQUEST.value(), "존재하지 않는 상품 번호입니다."),
 	INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST.value(), "가용한 재고가 부족합니다."),
-	INSUFFICIENT_STOCK_INFORMATION(HttpStatus.BAD_REQUEST.value(), "재고 정보가 부족합니다.");
+	INSUFFICIENT_STOCK_INFORMATION(HttpStatus.BAD_REQUEST.value(), "재고 정보가 부족합니다."),
+	NOT_AVAILABLE_PRODUCT(HttpStatus.BAD_REQUEST.value(), "판매하지 않는 상품입니다.");
 	private final int code;
 	private final String message;
 }

--- a/order-api/src/main/java/org/ecommerce/orderapi/repository/StockHistoryRepository.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/repository/StockHistoryRepository.java
@@ -1,0 +1,9 @@
+package org.ecommerce.orderapi.repository;
+
+import org.ecommerce.orderapi.entity.StockHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StockHistoryRepository extends JpaRepository<StockHistory, Long> {
+}

--- a/order-api/src/main/java/org/ecommerce/orderapi/service/OrderService.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/service/OrderService.java
@@ -147,18 +147,8 @@ public class OrderService {
 				products
 		);
 
-		List<OrderStatusHistory> orderStatusHistories = orderDetails.stream()
-				.map(orderDetail -> OrderStatusHistory.ofRecord(
-						orderDetail,
-						OrderStatus.OPEN
-				))
-				.toList();
-
-		IntStream.range(0, orderDetails.size())
-				.forEach(i -> orderDetails.get(i)
-						.recordOrderStatusHistory(orderStatusHistories.get(i)));
+		recordOrderStatusHistory(orderDetails);
 		order.attachOrderDetails(orderDetails);
-
 		orderRepository.save(order);
 		return OrderMapper.INSTANCE.toDto(order);
 	}
@@ -193,5 +183,25 @@ public class OrderService {
 					);
 				})
 				.toList();
+	}
+
+	/**
+	 * 주문 상세에 대한 상태 이력을 기록하는 메소드입니다.
+	 * @author ${Juwon}
+	 *
+	 * @param orderDetails - 주문 상세 리스트
+	*/
+	@VisibleForTesting
+	public void recordOrderStatusHistory(final List<OrderDetail> orderDetails) {
+		List<OrderStatusHistory> orderStatusHistories = orderDetails.stream()
+				.map(orderDetail -> OrderStatusHistory.ofRecord(
+						orderDetail,
+						OrderStatus.OPEN
+				))
+				.toList();
+
+		IntStream.range(0, orderDetails.size())
+				.forEach(i -> orderDetails.get(i)
+						.recordOrderStatusHistory(orderStatusHistories.get(i)));
 	}
 }

--- a/order-api/src/main/java/org/ecommerce/orderapi/service/OrderService.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/service/OrderService.java
@@ -80,14 +80,14 @@ public class OrderService {
 	) {
 		List<Stock> stocks = redisClient.getStocks(productIds);
 
-		for (Stock stock : stocks) {
+		stocks.forEach(stock -> {
 			if (stock.getTotal() == null || stock.getProcessingCnt() == null) {
 				throw new CustomException(INSUFFICIENT_STOCK_INFORMATION);
 			}
 			if (stock.getAvailableStock() < quantities.get(stock.getProductId())) {
 				throw new CustomException(INSUFFICIENT_STOCK);
 			}
-		}
+		});
 	}
 
 	/**

--- a/order-api/src/main/java/org/ecommerce/orderapi/service/OrderService.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/service/OrderService.java
@@ -38,6 +38,7 @@ public class OrderService {
 	private final BucketServiceClient bucketServiceClient;
 	private final OrderRepository orderRepository;
 	private final RedisClient redisClient;
+	private final StockService stockService;
 
 	private final static Integer DELIVERY_FEE = 0;
 
@@ -98,14 +99,14 @@ public class OrderService {
 	 */
 	@VisibleForTesting
 	public void validateProduct(final List<Product> products) {
-		for (Product product : products) {
+		products.forEach(product -> {
 			if (product == null) {
 				throw new CustomException(NOT_FOUND_PRODUCT_ID);
 			}
 			if (product.getStatus() != ProductStatus.AVAILABLE) {
 				throw new CustomException(NOT_AVAILABLE_PRODUCT);
 			}
-		}
+		});
 	}
 
 	// TODO : 회원 유효성 검사
@@ -150,6 +151,7 @@ public class OrderService {
 		recordOrderStatusHistory(orderDetails);
 		order.attachOrderDetails(orderDetails);
 		orderRepository.save(order);
+		stockService.increaseInProcessingStocks(orderDetails);
 		return OrderMapper.INSTANCE.toDto(order);
 	}
 

--- a/order-api/src/main/java/org/ecommerce/orderapi/service/ProductService.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/service/ProductService.java
@@ -25,7 +25,7 @@ public class ProductService {
 	/**
 	 * MockData 만드는 메소드입니다.
 	 * @author ${Juwon}
-	*/
+	 */
 	public void saveMock() {
 
 		List<Product> mockProducts = Arrays.asList(
@@ -41,10 +41,10 @@ public class ProductService {
 		);
 
 		IntStream.range(0, mockStocks.size())
-				.forEach(i -> redisClient.registerProduct(
-						mockProducts.get(i),
-						mockStocks.get(i)
-				));
+				.forEach(i -> {
+					redisClient.setProduct(mockProducts.get(i));
+					redisClient.putStock(mockStocks.get(i));
+				});
 	}
 
 	/**

--- a/order-api/src/main/java/org/ecommerce/orderapi/service/ProductService.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/service/ProductService.java
@@ -1,5 +1,6 @@
 package org.ecommerce.orderapi.service;
 
+import static org.ecommerce.orderapi.entity.type.ProductStatus.*;
 import static org.ecommerce.orderapi.exception.OrderErrorCode.*;
 
 import java.util.Arrays;
@@ -28,9 +29,9 @@ public class ProductService {
 	public void saveMock() {
 
 		List<Product> mockProducts = Arrays.asList(
-				new Product(101, "아라비카", 10000, "seller1"),
-				new Product(102, "로부스타", 20000, "seller2"),
-				new Product(103, "리베리카", 30000, "seller3")
+				new Product(101, "아라비카", 10000, "seller1", AVAILABLE),
+				new Product(102, "로부스타", 20000, "seller2", AVAILABLE),
+				new Product(103, "리베리카", 30000, "seller3", AVAILABLE)
 		);
 
 		List<Stock> mockStocks = Arrays.asList(
@@ -60,22 +61,5 @@ public class ProductService {
 				product.getPrice(),
 				stock.getAvailableStock(),
 				product.getSeller());
-	}
-
-	/**
-	 * Products 정보를 가져오는 메소드입니다.
-	 * @author ${Juwon}
-	 *
-	 * @param productIds- 상품 번호 리스트
-	 * @return - 반환 값 설명 텍스트
-	*/
-	public List<Product> getProducts(final List<Integer> productIds) {
-		List<Product> products = redisClient.getProducts(productIds);
-		for (Product product : products) {
-			if (product == null) {
-				throw new CustomException(NOT_FOUND_PRODUCT_ID);
-			}
-		}
-		return products;
 	}
 }

--- a/order-api/src/main/java/org/ecommerce/orderapi/service/StockService.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/service/StockService.java
@@ -40,6 +40,7 @@ public class StockService {
 		orderDetails.forEach(orderDetail -> {
 			final Integer productId = orderDetail.getProductId();
 			final Integer quantity = orderDetail.getQuantity();
+			RLock lock = redisClient.getLock(productId);
 			final Stock stock = redisClient.getStock(productId)
 					.orElseThrow(
 							() -> new CustomException(INSUFFICIENT_STOCK_INFORMATION));
@@ -47,7 +48,6 @@ public class StockService {
 			if (!validateQuantity(stock, quantity)) {
 				throw new CustomException(INSUFFICIENT_STOCK);
 			}
-			RLock lock = redisClient.getLock(productId);
 			RTransaction transaction = redisClient.beginTransaction();
 			try {
 				increaseInProcessingStock(transaction, stock, quantity);

--- a/order-api/src/main/java/org/ecommerce/orderapi/service/StockService.java
+++ b/order-api/src/main/java/org/ecommerce/orderapi/service/StockService.java
@@ -1,58 +1,136 @@
 package org.ecommerce.orderapi.service;
 
+import static org.ecommerce.orderapi.entity.type.ProductStatus.*;
 import static org.ecommerce.orderapi.exception.OrderErrorCode.*;
+
+import java.util.List;
+import java.util.Objects;
 
 import org.ecommerce.common.error.CustomException;
 import org.ecommerce.orderapi.client.RedisClient;
+import org.ecommerce.orderapi.entity.OrderDetail;
+import org.ecommerce.orderapi.entity.Product;
 import org.ecommerce.orderapi.entity.Stock;
+import org.ecommerce.orderapi.entity.StockHistory;
 import org.ecommerce.orderapi.repository.StockHistoryRepository;
+import org.redisson.api.RLock;
+import org.redisson.api.RTransaction;
 import org.springframework.stereotype.Service;
 
 import com.google.common.annotations.VisibleForTesting;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class StockService {
 
 	private final RedisClient redisClient;
 	private final StockHistoryRepository stockHistoryRepository;
 
-	public void increaseStock(final Integer productId, final Integer quantity) {
-		Stock stock = redisClient.getStock(productId)
-				.orElseThrow(() -> new CustomException(NOT_FOUND_PRODUCT_ID));
-
-		if (!validateStock(stock)) {
-			throw new CustomException(INSUFFICIENT_STOCK_INFORMATION);
-		}
-		if (!validateQuantity(stock.getAvailableStock(), quantity)) {
-			throw new CustomException(INSUFFICIENT_STOCK);
-		}
-	}
-
 	/**
-	 * 재고를 검증하는 메소드입니다.
-	 * @author ${juwon}
-	 *
-	 * @param stock- 재고
-	 * @return - 검증 결과
-	*/
-	@VisibleForTesting
-	public boolean validateStock(final Stock stock) {
-		return stock.getTotal() != null && stock.getProcessingCnt() != null;
-	}
-
-	/**
-	 * 가용한 상품 수량인지 검증하는 메소드입니다.
+	 * 처리중인 재고를 증가시키는 메소드입니다.
 	 * @author ${Juwon}
 	 *
-	 * @param availableStock- 가용한 재고
-	 * @param quantity- 주문 상품 수량
-	 * @return - 검증 결과
+	 * @param orderDetails- 주문 상세 리스트
+	*/
+	public void increaseInProcessingStocks(final List<OrderDetail> orderDetails) {
+		orderDetails.forEach(orderDetail -> {
+			final Integer productId = orderDetail.getProductId();
+			final Integer quantity = orderDetail.getQuantity();
+			final Stock stock = redisClient.getStock(productId)
+					.orElseThrow(
+							() -> new CustomException(INSUFFICIENT_STOCK_INFORMATION));
+
+			if (!validateQuantity(stock, quantity)) {
+				throw new CustomException(INSUFFICIENT_STOCK);
+			}
+			RLock lock = redisClient.getLock(productId);
+			RTransaction transaction = redisClient.beginTransaction();
+			try {
+				increaseInProcessingStock(transaction, stock, quantity);
+				checkSoldOut(transaction, stock, quantity);
+				saveStockHistory(orderDetail);
+				transaction.commit();
+				lock.unlock();
+			} catch (Exception e) {
+				transaction.rollback();
+				lock.unlock();
+				log.info("Error occurred while increasing stocks: {}", e.getMessage());
+			}
+		});
+	}
+
+	/**
+	 * stock 객체의 ProcessingCnt를 증가시키고 트랜잭션으로 묶는 메소드입니다.
+	 * @author ${Juwon}
+	 *
+	 * @param transaction- Redisson 트랜잭션
+	 * @param stock- 재고 객체
+	 * @param quantity- 주문 수량
+	 * @return - 반환 값 설명 텍스트
 	*/
 	@VisibleForTesting
-	public boolean validateQuantity(final Integer availableStock, final Integer quantity) {
-		return availableStock >= quantity;
+	public void increaseInProcessingStock(
+			final RTransaction transaction,
+			final Stock stock,
+			final Integer quantity
+	) {
+		stock.increaseProcessingCnt(quantity);
+		redisClient.increaseInProcessingStock(transaction, stock);
 	}
+
+	/**
+	 * 주문 수량을 검증하는 메소드입니다.
+	 * @author ${Juwon}
+	 *
+	 * @param stock- 재고 객체
+	 * @param quantity- 주문 수량
+	 * @return - 반환 값 설명 텍스트
+	*/
+	@VisibleForTesting
+	public boolean validateQuantity(final Stock stock, final Integer quantity) {
+		return stock.getAvailableStock() > quantity;
+	}
+
+	/**
+	 * 상품 매진을 확인하고, 트랜잭션으로 묶는 메소드입니다.
+	 * @author ${Juwon}
+	 *
+	 * @param transaction- Redisson 트랜잭션
+	 * @param stock- 재고 객체
+	 * @param quantity- 주문 수량
+	*/
+	@VisibleForTesting
+	public void checkSoldOut(
+			final RTransaction transaction,
+			final Stock stock,
+			final Integer quantity
+	) {
+		if (Objects.equals(stock.getAvailableStock(), quantity)) {
+			Product product = redisClient.getProduct(stock.getProductId()).orElseThrow(
+					() -> new CustomException(NOT_FOUND_PRODUCT_ID)
+			);
+			product.changeStatus(OUT_OF_STOCK);
+			redisClient.soldOutProduct(transaction, product);
+		}
+	}
+
+	/**
+	 * 재고 로그를 기록하는 메소드입니다.
+	 * @author ${Juwon}
+	 *
+	 * @param orderDetail- 상세 주문 객체
+	*/
+	@VisibleForTesting
+	public void saveStockHistory(final OrderDetail orderDetail) {
+		stockHistoryRepository.save(StockHistory.ofRecord(
+				orderDetail.getId(),
+				orderDetail.getProductId(),
+				orderDetail.getQuantity()
+		));
+	}
+
 }


### PR DESCRIPTION
## 개요
주문에 대한 재고 처리 비즈니스 로직을 구현하였습니다.
일괄 주문 중 특정 재고 처리를 실패하였을 때 모든 주문에 대한 롤백 처리는 미구현 되어있습니다.

재고 변경사항
재고에 대한 redis Hash key를 고정 키 -> 상품 번호에 대한 key 변경하였습니다.
1. 하나의 Map에 많은 요청이 몰리면 성능 이슈가 발생합니다.
2. 확장성과 유연성을 고려했습니다.

상품 변경사항
하나의 Map<productId, Product> -> Bucket<Product> 변경
redisson에서 객체 handlering을 지원하는 Bucket으로 변경하였고 key도 고정 키 -> 상품 번호에 대한 key 변경
## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [x] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 

> ### Description

- 주문 상태 이력 생성 로직 구현
- 주문에 대한 재고 처리 로직, 로그 생성 구현

트랜잭션을 분리하여 상세 주문별 Transaction을 적용하였습니다.
![image](https://github.com/Team-Koreano/Koreano/assets/90291431/242389bf-4744-4fe2-84b7-23242cbc24df)
[[Koreano] stock management
](https://blog.naver.com/smileman___/223416744799)